### PR TITLE
Fix potential memory leak

### DIFF
--- a/SwiftyNotifications/SwiftyNotificationsDrawings.swift
+++ b/SwiftyNotifications/SwiftyNotificationsDrawings.swift
@@ -157,11 +157,11 @@ extension UIImage {
 
     func scaleImageToSize(size: CGSize) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+        defer { UIGraphicsEndImageContext() }
         draw(in: CGRect(x: 0.0, y: 0.0, width: size.width, height: size.height))
         guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
             return self
         }
-        UIGraphicsEndImageContext()
         return image
     }
 


### PR DESCRIPTION
I thought the UIGraphicsBeginImageContextWithOptions(size, false, 0.0) should in every case be followed be a call to UIGraphicsEndImageContext(). 
It's very rare that a call to UIGraphicsGetImageFromCurrentImageContext() doesn't get you an image back, but you handle this case in your code and so you should handle the Context accordingly. 